### PR TITLE
Fix IndexError when generating wallet stats

### DIFF
--- a/massa_acheta_docker/remotes/wallet.py
+++ b/massa_acheta_docker/remotes/wallet.py
@@ -201,7 +201,12 @@ async def check_wallet(node_name: str="", wallet_address: str="") -> None:
 
             app_globals.app_results[node_name]['wallets'][wallet_address]['last_result'] = wallet_result
 
-            final_cycle = wallet_cycle_infos[-2]
+            # Use the previous cycle stats if available,
+            # otherwise fall back to the latest cycle to avoid IndexError
+            if len(wallet_cycle_infos) >= 2:
+                final_cycle = wallet_cycle_infos[-2]
+            else:
+                final_cycle = wallet_cycle_infos[-1]
 
             wallet_last_cycle = 0
             if type(final_cycle.get("cycle", 0)) == int:


### PR DESCRIPTION
## Summary
- avoid IndexError when wallet history has only one cycle

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f30edf6cc8328972a2a9f40116018