### PR TITLE
Persist runtime node/wallet state

### DIFF
--- a/massa_acheta_docker/app_globals.py
+++ b/massa_acheta_docker/app_globals.py
@@ -62,31 +62,32 @@ else:
     else:
         logger.info(f"Successfully created empty '{app_results_obj}' file")
 
-for node_name in app_results:
-    app_results[node_name]['last_status'] = "unknown"
-    app_results[node_name]['last_update'] = 0
-    app_results[node_name]['start_time'] = 0
-    app_results[node_name]['last_chain_id'] = 0
-    app_results[node_name]['last_cycle'] = 0
-    app_results[node_name]['last_result'] = {"unknown": "Never updated before"}
+for node_name, node_data in app_results.items():
+    node_data.setdefault('last_status', "unknown")
+    node_data.setdefault('last_update', 0)
+    node_data.setdefault('start_time', 0)
+    node_data.setdefault('last_chain_id', 0)
+    node_data.setdefault('last_cycle', 0)
+    node_data.setdefault('last_result', {"unknown": "Never updated before"})
 
-    for wallet_address in app_results[node_name]['wallets']:
-        app_results[node_name]['wallets'][wallet_address] = {}
-        app_results[node_name]['wallets'][wallet_address]['last_status'] = "unknown"
-        app_results[node_name]['wallets'][wallet_address]['last_update'] = 0
-        app_results[node_name]['wallets'][wallet_address]['final_balance'] = 0
-        app_results[node_name]['wallets'][wallet_address]['candidate_rolls'] = 0
-        app_results[node_name]['wallets'][wallet_address]['active_rolls'] = 0
-        app_results[node_name]['wallets'][wallet_address]['missed_blocks'] = 0
-        app_results[node_name]['wallets'][wallet_address]['last_cycle'] = 0
-        app_results[node_name]['wallets'][wallet_address]['last_ok_count'] = 0
-        app_results[node_name]['wallets'][wallet_address]['last_nok_count'] = 0
-        app_results[node_name]['wallets'][wallet_address]['last_result'] = {"unknown": "Never updated before"}
-        app_results[node_name]['wallets'][wallet_address]['stat'] = deque(
-            maxlen=int(
-                24 * 60 / app_config['service']['main_loop_period_min']
+    for wallet_address, wallet_data in node_data.get('wallets', {}).items():
+        node_data['wallets'][wallet_address].setdefault('last_status', "unknown")
+        node_data['wallets'][wallet_address].setdefault('last_update', 0)
+        node_data['wallets'][wallet_address].setdefault('final_balance', 0)
+        node_data['wallets'][wallet_address].setdefault('candidate_rolls', 0)
+        node_data['wallets'][wallet_address].setdefault('active_rolls', 0)
+        node_data['wallets'][wallet_address].setdefault('missed_blocks', 0)
+        node_data['wallets'][wallet_address].setdefault('last_cycle', 0)
+        node_data['wallets'][wallet_address].setdefault('last_ok_count', 0)
+        node_data['wallets'][wallet_address].setdefault('last_nok_count', 0)
+        node_data['wallets'][wallet_address].setdefault('produced_blocks', 0)
+        node_data['wallets'][wallet_address].setdefault('last_result', {"unknown": "Never updated before"})
+        if 'stat' not in node_data['wallets'][wallet_address] or not isinstance(node_data['wallets'][wallet_address]['stat'], deque):
+            node_data['wallets'][wallet_address]['stat'] = deque(
+                maxlen=int(
+                    24 * 60 / app_config['service']['main_loop_period_min']
+                )
             )
-        )
 
 
 

--- a/massa_acheta_docker/main.py
+++ b/massa_acheta_docker/main.py
@@ -34,7 +34,7 @@ from telegram.handlers import massa_info, massa_chart, acheta_release
 from telegram.handlers import reset
 from telegram.handlers import unknown
 
-from tools import save_app_stat, save_public_dir
+from tools import save_app_stat, save_public_dir, save_app_results
 
 
 @logger.catch
@@ -161,6 +161,7 @@ if __name__ == "__main__":
         logger.error(f"Exception {str(E)} ({E})")
     
     finally:
+        save_app_results()
         save_app_stat()
         save_public_dir()
 

--- a/massa_acheta_docker/remotes/monitor.py
+++ b/massa_acheta_docker/remotes/monitor.py
@@ -8,6 +8,7 @@ import app_globals
 from remotes.node import check_node
 from remotes.wallet import check_wallet
 from remotes.releases import check_releases
+from tools import save_app_results
 
 
 @logger.catch
@@ -28,6 +29,7 @@ async def monitor() -> None:
             async with app_globals.results_lock:
                 await asyncio.gather(*node_coros)
                 await asyncio.gather(*wallet_coros)
+                save_app_results()
 
             await asyncio.gather(check_releases())
 

--- a/massa_acheta_docker/tools.py
+++ b/massa_acheta_docker/tools.py
@@ -86,13 +86,40 @@ def save_app_results() -> bool:
     composed_results = {}
 
     try:
-        for node_name in app_globals.app_results:
+        for node_name, node_data in app_globals.app_results.items():
             composed_results[node_name] = {}
-            composed_results[node_name]['url'] = app_globals.app_results[node_name]['url']
-            composed_results[node_name]['wallets'] = {}
+            # Save node static and dynamic fields (except stats)
+            for field in [
+                "url",
+                "last_status",
+                "last_update",
+                "start_time",
+                "last_chain_id",
+                "last_cycle",
+                "last_result",
+            ]:
+                composed_results[node_name][field] = node_data.get(field, None)
 
-            for wallet_address in app_globals.app_results[node_name]['wallets']:
-                composed_results[node_name]['wallets'][wallet_address] = {}
+            composed_results[node_name]["wallets"] = {}
+
+            for wallet_address, wallet_data in node_data.get("wallets", {}).items():
+                composed_results[node_name]["wallets"][wallet_address] = {}
+                for w_field in [
+                    "last_status",
+                    "last_update",
+                    "final_balance",
+                    "candidate_rolls",
+                    "active_rolls",
+                    "missed_blocks",
+                    "last_cycle",
+                    "last_ok_count",
+                    "last_nok_count",
+                    "produced_blocks",
+                    "last_result",
+                ]:
+                    composed_results[node_name]["wallets"][wallet_address][w_field] = wallet_data.get(
+                        w_field, None
+                    )
 
         app_results_obj = Path(app_config['service']['results_path'])
         with open(file=app_results_obj, mode="wt") as output_results:


### PR DESCRIPTION
## Summary
- store dynamic node and wallet fields when saving results
- restore saved fields on start
- persist state after every monitoring cycle and on shutdown

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851af86a46c8328bcca92ce1b906c3c