### PR TITLE
Improve HTTP API error handling

### DIFF
--- a/massa_acheta_docker/tools.py
+++ b/massa_acheta_docker/tools.py
@@ -59,11 +59,15 @@ async def pull_http_api(api_url: str=None,
             if not api_root_element:
                 api_result = {"result": api_response_obj}
             else:
-                api_result = api_response_obj.get(api_root_element, None)
-                if not api_result:
-                    raise Exception(f"A mandatory key '{api_root_element}' missed in remote HTTP API response: {api_response_text}")
+                api_result_value = api_response_obj.get(api_root_element, None)
+                if api_result_value is not None:
+                    api_result = {"result": api_result_value}
+                elif "error" in api_response_obj:
+                    api_result = {"error": api_response_obj["error"]}
                 else:
-                    api_result = {"result": api_result}
+                    raise Exception(
+                        f"A mandatory key '{api_root_element}' missed in remote HTTP API response: {api_response_text}"
+                    )
         else:
             api_result = {"result": api_response_text}
 


### PR DESCRIPTION
## Summary
- handle `error` fields in HTTP API responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851cb4fc6388328ad1c084827a0e4f0