### PR TITLE
Centralize telegram menu definition

### DIFF
--- a/massa_acheta_docker/main.py
+++ b/massa_acheta_docker/main.py
@@ -12,7 +12,7 @@ logger.add(
 
 import asyncio
 from aiogram.utils.formatting import as_list
-from aiogram.types import BotCommand
+from telegram.menu import get_bot_commands
 from pathlib import Path
 from sys import exit as sys_exit
 
@@ -42,43 +42,13 @@ async def main() -> None:
     logger.debug(f"-> Enter Def")
 
     public_obj = Path("public")
-    if not public_obj.exists():
+    public = public_obj.exists()
+    if not public:
         logger.info(f"No file '{public_obj}' exists. Private menu applied.")
-        bot_commands = [
-            BotCommand(command="/help", description="Show help info"),
-            BotCommand(command="/view_config", description="View service config"),
-            BotCommand(command="/view_node", description="View node status"),
-            BotCommand(command="/view_wallet", description="View wallet info"),
-            BotCommand(command="/chart_wallet", description="View wallet chart"),
-            BotCommand(command="/view_address", description="View any wallet info"),
-            BotCommand(command="/clean_address", description="Clean remembered address"),
-            BotCommand(command="/view_credits", description="View any wallet credits"),
-            BotCommand(command="/view_earnings", description="View rewards for staking"),
-            BotCommand(command="/add_node", description="Add node to bot"),
-            BotCommand(command="/add_wallet", description="Add wallet to bot"),
-            BotCommand(command="/delete_node", description="Delete node from bot"),
-            BotCommand(command="/delete_wallet", description="Delete wallet from bot"),
-            BotCommand(command="/massa_info", description="Show MASSA network info"),
-            BotCommand(command="/massa_chart", description="Show MASSA network chart"),
-            BotCommand(command="/acheta_release", description="Actual Acheta release"),
-            BotCommand(command="/view_id", description="Show your TG ID"),
-            BotCommand(command="/cancel", description="Cancel ongoing scenario"),
-            BotCommand(command="/reset", description="Reset bot configuration")
-        ]
-
     else:
         logger.info(f"File '{public_obj}' exists. Public menu applied.")
-        bot_commands = [
-            BotCommand(command="/help", description="Show help info"),
-            BotCommand(command="/view_address", description="View any wallet info"),
-            BotCommand(command="/clean_address", description="Clean remembered address"),
-            BotCommand(command="/view_credits", description="View any wallet credits"),
-            BotCommand(command="/view_earnings", description="View rewards for staking"),
-            BotCommand(command="/massa_info", description="Show MASSA network info"),
-            BotCommand(command="/massa_chart", description="Show MASSA network chart"),
-            BotCommand(command="/view_id", description="Show your TG ID"),
-            BotCommand(command="/cancel", description="Cancel ongoing scenario")
-        ]
+
+    bot_commands = get_bot_commands(public)
 
     await app_globals.tg_bot.set_my_commands(bot_commands)
 

--- a/massa_acheta_docker/telegram/handlers/start.py
+++ b/massa_acheta_docker/telegram/handlers/start.py
@@ -3,7 +3,7 @@ from loguru import logger
 from aiogram import Router
 from aiogram.filters import Command, StateFilter
 from aiogram.types import Message
-from aiogram.utils.formatting import as_list, as_line, TextLink
+from telegram.menu import build_help_text
 from aiogram.enums import ParseMode
 
 from app_config import app_config
@@ -19,103 +19,12 @@ async def cmd_start(message: Message) -> None:
     logger.debug("-> Enter Def")
     logger.info(f"-> Got '{message.text}' command from '{message.from_user.id}'@'{message.chat.id}'")
 
-    if message.chat.id != app_globals.bot.ACHETA_CHAT:
-        t = as_list(
-            "📖 Commands:",
-            "⦙",
-            "⦙… /start or /help : This message",
-            "⦙",
-            "⦙… /view_address : View any wallet info",
-            "⦙",
-            "⦙… /clean_address : Clean your remembered address",
-            "⦙",
-            "⦙… /view_credits : View any wallet credits",
-            "⦙",
-            "⦙… /view_earnings : View earnings for Rolls number",
-            "⦙",
-            "⦙… /massa_info : Show MASSA network info",
-            "⦙",
-            "⦙… /massa_chart : Show MASSA network chart",
-            "⦙",
-            "⦙… /view_id : Show your TG ID",
-            "⦙",
-            "⦙… /cancel : Cancel ongoing scenario", "",
-            as_line(
-                "👉 ",
-                TextLink(
-                    "More info here",
-                    url="https://github.com/dex2code/massa_acheta/"
-                )
-            ),
-            as_line(
-                "🎁 Wanna thank the author? ",
-                TextLink(
-                    "Ask me how",
-                    url="https://github.com/dex2code/massa_acheta#thank-you"
-                )
-            )
-        )
-
-    else:
-        t = as_list(
-            "📖 Commands:",
-            "⦙",
-            "⦙… /start or /help : This message",
-            "⦙",
-            "⦙… /view_config : View service config",
-            "⦙",
-            "⦙… /view_node : View node status",
-            "⦙",
-            "⦙… /view_wallet : View wallet info",
-            "⦙",
-            "⦙… /chart_wallet : View wallet chart",
-            "⦙",
-            "⦙… /view_address : View any wallet info",
-            "⦙",
-            "⦙… /clean_address : Clean your remembered address",
-            "⦙",
-            "⦙… /view_credits : View any wallet credits",
-            "⦙",
-            "⦙… /view_earnings : View earnings for Rolls number",
-            "⦙",
-            "⦙… /add_node : Add node to bot",
-            "⦙",
-            "⦙… /add_wallet : Add wallet to bot",
-            "⦙",
-            "⦙… /delete_node : Delete node from bot",
-            "⦙",
-            "⦙… /delete_wallet : Delete wallet from bot",
-            "⦙",
-            "⦙… /massa_info : MASSA network info",
-            "⦙",
-            "⦙… /massa_chart : Show MASSA network chart",
-            "⦙",
-            "⦙… /acheta_release : Actual Acheta release",
-            "⦙",
-            "⦙… /view_id : Show your TG ID",
-            "⦙",
-            "⦙… /cancel : Cancel ongoing scenario",
-            "⦙",
-            "⦙… /reset : Reset configuration", "",
-            as_line(
-                "👉 ",
-                TextLink(
-                    "More info here",
-                    url="https://github.com/dex2code/massa_acheta/"
-                )
-            ),
-            as_line(
-                "🎁 Wanna thank the author? ",
-                TextLink(
-                    "Ask me how",
-                    url="https://github.com/dex2code/massa_acheta#thank-you"
-                )
-            )
-        )
+    public = message.chat.id != app_globals.bot.ACHETA_CHAT
+    t = build_help_text(public)
 
     try:
         await message.reply(
-            text=t.as_html(),
+            text=t,
             parse_mode=ParseMode.HTML,
             request_timeout=app_config['telegram']['sending_timeout_sec']
         )

--- a/massa_acheta_docker/telegram/menu.py
+++ b/massa_acheta_docker/telegram/menu.py
@@ -1,0 +1,58 @@
+from aiogram.types import BotCommand
+from aiogram.utils.formatting import as_list, as_line, TextLink
+
+# Tuples of (command, description) for the private bot mode
+PRIVATE_COMMANDS: list[tuple[str, str]] = [
+    ("/help", "Show help info"),
+    ("/view_config", "View service config"),
+    ("/view_node", "View node status"),
+    ("/view_wallet", "View wallet info"),
+    ("/chart_wallet", "View wallet chart"),
+    ("/view_address", "View any wallet info"),
+    ("/clean_address", "Clean remembered address"),
+    ("/view_credits", "View any wallet credits"),
+    ("/view_earnings", "View rewards for staking"),
+    ("/add_node", "Add node to bot"),
+    ("/add_wallet", "Add wallet to bot"),
+    ("/delete_node", "Delete node from bot"),
+    ("/delete_wallet", "Delete wallet from bot"),
+    ("/massa_info", "Show MASSA network info"),
+    ("/massa_chart", "Show MASSA network chart"),
+    ("/acheta_release", "Actual Acheta release"),
+    ("/view_id", "Show your TG ID"),
+    ("/cancel", "Cancel ongoing scenario"),
+    ("/reset", "Reset bot configuration"),
+]
+
+# Tuples of (command, description) for the public bot mode
+PUBLIC_COMMANDS: list[tuple[str, str]] = [
+    ("/help", "Show help info"),
+    ("/view_address", "View any wallet info"),
+    ("/clean_address", "Clean remembered address"),
+    ("/view_credits", "View any wallet credits"),
+    ("/view_earnings", "View rewards for staking"),
+    ("/massa_info", "Show MASSA network info"),
+    ("/massa_chart", "Show MASSA network chart"),
+    ("/view_id", "Show your TG ID"),
+    ("/cancel", "Cancel ongoing scenario"),
+]
+
+def get_bot_commands(public: bool) -> list[BotCommand]:
+    """Return list of BotCommand objects for the current mode."""
+    commands = PUBLIC_COMMANDS if public else PRIVATE_COMMANDS
+    return [BotCommand(command=cmd, description=desc) for cmd, desc in commands]
+
+def build_help_text(public: bool) -> str:
+    """Build help message text in HTML format."""
+    commands = PUBLIC_COMMANDS if public else PRIVATE_COMMANDS
+    lines: list[str | object] = ["📖 Commands:", "⦙", "⦙… /start or /help : Show help info", "⦙"]
+    for cmd, desc in commands:
+        if cmd == "/help":
+            continue
+        lines.append(f"⦙… {cmd} : {desc}")
+        lines.append("⦙")
+    lines.extend([
+        as_line("👉 ", TextLink("More info here", url="https://github.com/dex2code/massa_acheta/")),
+        as_line("🎁 Wanna thank the author? ", TextLink("Ask me how", url="https://github.com/dex2code/massa_acheta#thank-you")),
+    ])
+    return as_list(*lines).as_html()


### PR DESCRIPTION
## Summary
- centralize telegram menu in new `menu` module
- generate bot command list and help text from shared tuples
- simplify `main.py` to use new helper
- display help message using common builder

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851ce8ccee88328adb29745564bb651