### PR TITLE
Add help keyboard for Telegram bot

### DIFF
--- a/massa_acheta_docker/README.md
+++ b/massa_acheta_docker/README.md
@@ -94,6 +94,8 @@ Before we jump to a detailed description of the service, please watch the video:
 
 ## What can Acheta do:
 
+Use `/help` in Telegram to display a menu with buttons for the available commands.
+
 ### 👉 Explore MASSA blockchain
 First of all it can observe MASSA explorer and display wallets info with command:
 >

--- a/massa_acheta_docker/telegram/handlers/start.py
+++ b/massa_acheta_docker/telegram/handlers/start.py
@@ -3,7 +3,7 @@ from loguru import logger
 from aiogram import Router
 from aiogram.filters import Command, StateFilter
 from aiogram.types import Message
-from telegram.menu import build_help_text
+from telegram.menu import build_help_text, build_help_keyboard
 from aiogram.enums import ParseMode
 
 from app_config import app_config
@@ -21,11 +21,13 @@ async def cmd_start(message: Message) -> None:
 
     public = message.chat.id != app_globals.bot.ACHETA_CHAT
     t = build_help_text(public)
+    keyboard = build_help_keyboard(public)
 
     try:
         await message.reply(
             text=t,
             parse_mode=ParseMode.HTML,
+            reply_markup=keyboard,
             request_timeout=app_config['telegram']['sending_timeout_sec']
         )
     except BaseException as E:

--- a/massa_acheta_docker/telegram/menu.py
+++ b/massa_acheta_docker/telegram/menu.py
@@ -1,4 +1,5 @@
-from aiogram.types import BotCommand
+from aiogram.types import BotCommand, ReplyKeyboardMarkup
+from aiogram.utils.keyboard import ReplyKeyboardBuilder
 from aiogram.utils.formatting import as_list, as_line, TextLink
 
 # Tuples of (command, description) for the private bot mode
@@ -56,3 +57,13 @@ def build_help_text(public: bool) -> str:
         as_line("🎁 Wanna thank the author? ", TextLink("Ask me how", url="https://github.com/dex2code/massa_acheta#thank-you")),
     ])
     return as_list(*lines).as_html()
+
+
+def build_help_keyboard(public: bool) -> ReplyKeyboardMarkup:
+    """Build a reply keyboard with available commands."""
+    commands = PUBLIC_COMMANDS if public else PRIVATE_COMMANDS
+    kb = ReplyKeyboardBuilder()
+    for cmd, _ in commands:
+        kb.button(text=cmd)
+    kb.adjust(2)
+    return kb.as_markup(resize_keyboard=True)


### PR DESCRIPTION
## Summary
- create new `build_help_keyboard` in `telegram/menu.py`
- show help keyboard on `/start` and `/help`
- mention `/help` button menu in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d30a50148328a5af0a3f09b51639