### PR TITLE
Remove deprecated public_dir support

### DIFF
--- a/massa_acheta_docker/.gitignore
+++ b/massa_acheta_docker/.gitignore
@@ -7,7 +7,6 @@ pyvenv.cfg
 deferred_credits.json
 app_results.json
 app_stat.json
-public_dir.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/massa_acheta_docker/README.md
+++ b/massa_acheta_docker/README.md
@@ -17,13 +17,9 @@ You can deploy MASSA Acheta easily using Docker for a reproducible, isolated set
 
 2. **Create your environment file (`.env`) at the project root:**
 
->
 > !! Please check if you have a **Telegram Bot API KEY** and you do know your own **Telegram ID** before start installation
->
 > How to create a new Telegam Bot and its API KEY: https://www.youtube.com/watch?v=UQrcOj63S2o
->
 > You can get your own Telegram ID here: https://t.me/getmyid_bot
->
 
    ```
    echo "ACHETA_KEY=YOUR_TELEGRAM_BOT_TOKEN" > .env
@@ -34,23 +30,13 @@ You can deploy MASSA Acheta easily using Docker for a reproducible, isolated set
 3. **Create required empty files at the root:**
 
 > **app_results.json:**
->
 > Stores the list of monitored nodes and wallets, their current state, configuration (URL, alias), and wallet tracking per node. It acts as the > main backup of user configuration (mapping: node <-> wallets <-> status).
 
->
 > **app_stat.json:**
->
 > Contains detailed history and statistics about nodes and wallets, used to restore historical data after a restart (per-period statistics,
 > previous states, and charts displayed in the Telegram interface).
 
->
-> **public_dir.json:**
->
-> Stores “public” users for multi-user or shared (optional) setups. Used to distinguish public access/settings from the private version.
-
->
 > **deferred_credits.json:**
->
 > Holds deferred credits for each wallet (e.g. upcoming rewards, scheduled payments, etc.). Used to display future credits for a wallet with
 > the /view_credits Telegram command.
 
@@ -83,9 +69,7 @@ docker compose down
 "MASSA Acheta" is a service that will notify you about events occurring on your MASSA node and your wallet.\
 Just like a little cricket!
 
->
 >First of all let's define that this is not a public Telegram Bot, but opensource software that you can install on your own server to get a personal Bot that will be accessible only to you.
->
 
 Before we jump to a detailed description of the service, please watch the video:
 
@@ -98,9 +82,7 @@ Use `/help` in Telegram to display a menu with buttons for the available command
 
 ### 👉 Explore MASSA blockchain
 First of all it can observe MASSA explorer and display wallets info with command:
->
 > `/view_address`
->
 ![view_address](https://github.com/dex2code/massa_acheta/blob/main/img/view_address.png?raw=true)
 
 ### 👉 Watch your node
@@ -108,9 +90,7 @@ First of all it can observe MASSA explorer and display wallets info with command
 
 
 In order to watch your node, you need to add it to the service configuration. To do this use the command:
->
 > `/add_node`
->
 Acheta will ask you for a node nickname (any unique value) and API URL to connect the node using MASSA public API.\
 Use `http://127.0.0.1:33035/api/v2` if you installed Acheta on the same host with MASSA node, otherwise replace `127.0.0.1` with your real MASSA node IP address.
 
@@ -126,16 +106,12 @@ If the node is available, Acheta will start monitoring the node and will notify 
 Every time the status changes, you will receive warning messages about it.
 Moreover, Acheta will notify you if your node becomes out of sync with the MASSA blockchain.
 You also can display actual node info using command:
->
 > `/view_node`
->
 ![view_node](https://github.com/dex2code/massa_acheta/blob/main/img/view_node.png?raw=true)
 
 ### 👉 Watch your staking
 In order to watch your wallet and staking activity, you need to add it to the service configuration. To do this use the command:
->
 > `/add_wallet`
->
 Acheta will ask you to select which node this wallet belongs to and will ask you to enter its address.
 
 After succesfuly adding a wallet, Acheta will try to obtain information about it from the node and display the status of this attempt.\
@@ -148,9 +124,7 @@ If the attempt is successful, Acheta will start to watch your wallet and will se
 Block notifications now rely on the counters of the last cycle, ensuring that no produced or missed block is lost even if the API only returns a limited history.
 
 You also can display actual wallet info using command:
->
 > `/view_wallet`
-> 
 ![view_wallet](https://github.com/dex2code/massa_acheta/blob/main/img/view_wallet.png?raw=true)
 
 ### 👉 Remind you about its status
@@ -160,28 +134,20 @@ These messages contains short useful information about your nodes and wallets, i
 
 ### 👉 Edit configuration
 To view your current configuration (added nodes and wallets) use command:
->
 > `/view_config`
->
 
 To remove added nodes or wallets use:
->
 > `/delete_node`\
 > `/delete_wallet`
->
 
 To reset the whole service configuration use:
->
 > `/reset`
->
 
 
 ### 👉 Watch full statistics of your added wallets
 Acheta collects statistics on all your added wallets and can show visual charts:
->
 > `/massa_info`\
 > `/massa_chart`
->
 ![massa_chart](https://github.com/dex2code/massa_acheta/blob/main/img/massa_chart.jpg?raw=true)
 ```
 Cycles collected: 34
@@ -189,10 +155,8 @@ Total stakers: 1,934 (d: -6)
 Total staked rolls: 363,222 (d: +1,551)
 ```
 
->
 > `/view_wallet`\
 > `/chart_wallet`
->
 ![chart_wallet](https://github.com/dex2code/massa_acheta/blob/main/img/wallet_staking_chart.jpg?raw=true)
 ```
 Cycles collected: 34
@@ -210,9 +174,7 @@ Fact Blocks / Cycle: 195.9706
 
 ### 👉 Watch deferred credits of any MASSA wallet
 Acheta can check provided MASSA wallet to display all future deferred credits (full list for two years)
->
 > `/view_credits`
->
 ![view_credits](https://github.com/dex2code/massa_acheta/blob/main/img/view_credits.png?raw=true)
 
 ## Notes

--- a/massa_acheta_docker/app_config.py
+++ b/massa_acheta_docker/app_config.py
@@ -12,7 +12,6 @@ app_config['telegram']['sending_timeout_sec'] = 5
 app_config['service']['results_path'] = "app_results.json"
 app_config['service']['deferred_credits_path'] = "deferred_credits.json"
 app_config['service']['stat_path'] = "app_stat.json"
-app_config['service']['public_dir_path'] = 'public_dir.json'
 
 app_config['service']['main_loop_period_min'] = 10
 app_config['service']['heartbeat_period_hours'] = 6

--- a/massa_acheta_docker/app_globals.py
+++ b/massa_acheta_docker/app_globals.py
@@ -213,26 +213,6 @@ else:
 
 
 
-### Init public_user_dir ###
-public_dir = {}
-
-public_dir_obj = Path(app_config['service']['public_dir_path'])
-
-if not public_dir_obj.exists():
-    logger.warning(f"No public_dir file '{public_dir_obj}' exists. Skipping...")
-
-else:
-    logger.info(f"Loading public_dir from '{public_dir_obj}' file...")
-
-    with open(file=public_dir_obj, mode="rt") as input_public_dir:
-        try:
-            public_dir = json.load(fp=input_public_dir)
-        
-        except BaseException as E:
-            logger.error(f"Cannot load public_dir from '{public_dir_obj}' file ({str(E)})")
-        
-        else:
-            logger.info(f"Successfully loaded public_dir from '{public_dir_obj}' file ({len(public_dir)} keys)")
 
 
 

--- a/massa_acheta_docker/docker-compose.yml
+++ b/massa_acheta_docker/docker-compose.yml
@@ -9,4 +9,3 @@ services:
       - ./app_results.json:/app/app_results.json
       - ./deferred_credits.json:/app/deferred_credits.json
       - ./app_stat.json:/app/app_stat.json
-      - ./public_dir.json:/app/public_dir.json

--- a/massa_acheta_docker/main.py
+++ b/massa_acheta_docker/main.py
@@ -34,7 +34,7 @@ from telegram.handlers import massa_info, massa_chart, acheta_release
 from telegram.handlers import reset
 from telegram.handlers import unknown
 
-from tools import save_app_stat, save_public_dir, save_app_results
+from tools import save_app_stat, save_app_results
 
 
 @logger.catch
@@ -133,7 +133,6 @@ if __name__ == "__main__":
     finally:
         save_app_results()
         save_app_stat()
-        save_public_dir()
 
         logger.critical("Service terminated")
         sys_exit()

--- a/massa_acheta_docker/remotes/heartbeat.py
+++ b/massa_acheta_docker/remotes/heartbeat.py
@@ -7,7 +7,7 @@ from app_config import app_config
 import app_globals
 
 from telegram.queue import queue_telegram_message
-from tools import get_last_seen, get_short_address, get_rewards_mas_day, save_public_dir, get_duration
+from tools import get_last_seen, get_short_address, get_rewards_mas_day, get_duration
 
 
 async def heartbeat() -> None:
@@ -107,7 +107,6 @@ async def heartbeat() -> None:
             )
             await queue_telegram_message(message_text=t.as_html())
 
-            save_public_dir()
 
     except BaseException as E:
         logger.error(f"Exception {str(E)} ({E})")

--- a/massa_acheta_docker/telegram/handlers/clean_address.py
+++ b/massa_acheta_docker/telegram/handlers/clean_address.py
@@ -8,7 +8,6 @@ from aiogram.enums import ParseMode
 from aiogram.utils.formatting import as_list
 
 from app_config import app_config
-import app_globals
 
 
 router = Router()
@@ -24,8 +23,6 @@ async def cmd_clean_address(message: Message) -> None:
         "🗑 Address wiped!"
     )
     try:
-        chat_id = str(message.chat.id)
-        app_globals.public_dir.pop(chat_id, None)
         await message.reply(
             text=t.as_html(),
             parse_mode=ParseMode.HTML,

--- a/massa_acheta_docker/telegram/handlers/view_address.py
+++ b/massa_acheta_docker/telegram/handlers/view_address.py
@@ -12,7 +12,7 @@ from aiogram.fsm.state import State, StatesGroup
 
 from app_config import app_config
 
-from tools import pull_http_api, get_short_address, get_rewards_mas_day, add_public_dir, get_public_dir
+from tools import pull_http_api, get_short_address, get_rewards_mas_day
 
 
 class AddressViewer(StatesGroup):
@@ -200,37 +200,27 @@ async def cmd_view_address(message: Message, state: FSMContext) -> None:
 
     message_list = message.text.split()
     if len(message_list) < 2:
-
-        public_wallet_address = await get_public_dir(chat_id=message.chat.id)
-        if public_wallet_address:
-            _, t = await get_address(wallet_address=public_wallet_address)
-
-        else:
-            t = as_list(
-                "❓ Please answer with a wallet address you want to explore: ", "",
-                as_line(
-                    "☝ The wallet address must start with ",
-                    Underline("AU"),
-                    " prefix"
-                ),
-                "👉 Use /cancel to quit the scenario"
-            )
-
+        t = as_list(
+            "❓ Please answer with a wallet address you want to explore: ", "",
+            as_line(
+                "☝ The wallet address must start with ",
+                Underline("AU"),
+                " prefix"
+            ),
+            "👉 Use /cancel to quit the scenario",
+        )
+        await state.set_state(AddressViewer.waiting_wallet_address)
         try:
-            if not public_wallet_address:
-                await state.set_state(AddressViewer.waiting_wallet_address)
-
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                request_timeout=app_config['telegram']['sending_timeout_sec']
+                request_timeout=app_config["telegram"]["sending_timeout_sec"]
             )
-
         except BaseException as E:
             logger.error(f"Could not send message to user '{message.from_user.id}' in chat '{message.chat.id}' ({str(E)})")
             await state.clear()
-
         return
+
 
     wallet_address = message_list[1]
     r, t = await get_address(wallet_address=wallet_address)
@@ -245,9 +235,6 @@ async def cmd_view_address(message: Message, state: FSMContext) -> None:
         logger.error(f"Could not send message to user '{message.from_user.id}' in chat '{message.chat.id}' ({str(E)})")
         await state.clear()
 
-    else:
-        if r:
-            await add_public_dir(chat_id=message.chat.id, wallet_address=wallet_address)
 
     return
 
@@ -277,10 +264,6 @@ async def show_address(message: Message, state: FSMContext) -> None:
     except BaseException as E:
         logger.error(f"Could not send message to user '{message.from_user.id}' in chat '{message.chat.id}' ({str(E)})")
     
-    else:
-        if r:
-            await add_public_dir(chat_id=message.chat.id, wallet_address=wallet_address)
-
     await state.clear()
     return
 
@@ -304,9 +287,5 @@ async def cmd_default(message: Message) -> None:
 
     except BaseException as E:
         logger.error(f"Could not send message to user '{message.from_user.id}' in chat '{message.chat.id}' ({str(E)})")
-
-    else:
-        if r:
-            await add_public_dir(chat_id=message.chat.id, wallet_address=wallet_address)
 
     return

--- a/massa_acheta_docker/telegram/handlers/view_credits.py
+++ b/massa_acheta_docker/telegram/handlers/view_credits.py
@@ -12,7 +12,7 @@ from aiogram.enums import ParseMode
 from app_config import app_config
 import app_globals
 
-from tools import get_short_address, t_now, get_public_dir, add_public_dir
+from tools import get_short_address, t_now
 
 
 class CreditsViewer(StatesGroup):
@@ -134,25 +134,17 @@ async def cmd_view_credits(message: Message, state: FSMContext) -> None:
     message_list = message.text.split()
     if len(message_list) < 2:
 
-        public_wallet_address = await get_public_dir(chat_id=message.chat.id)
-        if public_wallet_address:
-            _, t = await get_credits(wallet_address=public_wallet_address)
-
-        else:
-            t = as_list(
-                "❓ Please answer with a wallet address you want to explore: ", "",
-                as_line(
-                    "☝ The wallet address must start with ",
-                    Underline("AU"),
-                    " prefix"
-                ),
-                "👉 Use /cancel to quit the scenario"
-            )
-
+        t = as_list(
+            "❓ Please answer with a wallet address you want to explore: ", "",
+            as_line(
+                "☝ The wallet address must start with ",
+                Underline("AU"),
+                " prefix"
+            ),
+            "👉 Use /cancel to quit the scenario",
+        )
+        await state.set_state(CreditsViewer.waiting_wallet_address)
         try:
-            if not public_wallet_address:
-                await state.set_state(CreditsViewer.waiting_wallet_address)
-
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
@@ -161,7 +153,6 @@ async def cmd_view_credits(message: Message, state: FSMContext) -> None:
         except BaseException as E:
             logger.error(f"Could not send message to user '{message.from_user.id}' in chat '{message.chat.id}' ({str(E)})")
             await state.clear()
-
         return
 
     wallet_address = message_list[1]
@@ -175,10 +166,6 @@ async def cmd_view_credits(message: Message, state: FSMContext) -> None:
 
     except BaseException as E:
         logger.error(f"Could not send message to user '{message.from_user.id}' in chat '{message.chat.id}' ({str(E)})")
-
-    else:
-        if r:
-            await add_public_dir(chat_id=message.chat.id, wallet_address=wallet_address)
 
     await state.clear()
     return
@@ -208,10 +195,6 @@ async def show_credits(message: Message, state: FSMContext) -> None:
 
     except BaseException as E:
         logger.error(f"Could not send message to user '{message.from_user.id}' in chat '{message.chat.id}' ({str(E)})")
-
-    else:
-        if r:
-            await add_public_dir(chat_id=message.chat.id, wallet_address=wallet_address)
 
     await state.clear()
     return

--- a/massa_acheta_docker/tools.py
+++ b/massa_acheta_docker/tools.py
@@ -375,61 +375,6 @@ async def get_rewards_blocks_cycle(rolls_number: int=0, total_rolls: int=0) -> f
 
 
 
-async def add_public_dir(chat_id: any, wallet_address: str="") -> bool:
-    logger.debug("-> Enter Def")
-
-    try:
-        chat_id = str(chat_id)
-        wallet_address = str(wallet_address)
-        app_globals.public_dir[chat_id] = wallet_address
-    
-    except BaseException as E:
-        logger.warning(f"Cannot save wallet '{wallet_address}' for user '{chat_id}' ({str(E)})")
-        return False
-    
-    else:
-        logger.info(f"Successfully saved wallet '{wallet_address}' for user '{chat_id}'")
-        return True
-
-
-async def get_public_dir(chat_id: any) -> str:
-    logger.debug("-> Enter Def")
-
-    public_wallet_address = None
-    try:
-        chat_id = str(chat_id)
-        public_wallet_address = app_globals.public_dir.get(chat_id, None)
-
-    except BaseException as E:
-        logger.warning(f"Cannot get public_wallet_addres for chat_id '{chat_id}' ({str(E)})")
-
-    if public_wallet_address:
-        logger.info(f"Found wallet '{public_wallet_address}' for chat_id '{chat_id}' in public_dir")
-        return str(public_wallet_address)
-
-    else:
-        logger.info(f"No wallet for chat_id '{chat_id}' in public_dir")
-        return None
-
-
-
-def save_public_dir() -> bool:
-    logger.debug("-> Enter Def")
-
-    try:
-        public_dir_obj = Path(app_config['service']['public_dir_path'])
-        with open(file=public_dir_obj, mode="wt") as output_public_dir:
-            output_public_dir.write(json.dumps(obj=app_globals.public_dir, indent=4))
-            output_public_dir.flush()
-                    
-    except BaseException as E:
-        logger.error(f"Cannot save public_dir into '{public_dir_obj}' file: ({str(E)})")
-        return False
-        
-    else:
-        logger.info(f"Successfully saved public_dir into '{public_dir_obj}' file!")
-        return True
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- drop `public_dir` file handling from config and globals
- remove public_dir helpers and calls
- clean up handlers relying on saved addresses
- update compose, gitignore and docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685244da6e688328892333ebdcc4a039