### PR TITLE
Remove /help references and update menu functions

### DIFF
--- a/massa_acheta_docker/README.md
+++ b/massa_acheta_docker/README.md
@@ -78,7 +78,7 @@ Before we jump to a detailed description of the service, please watch the video:
 
 ## What can Acheta do:
 
-Use `/help` in Telegram to display a menu with buttons for the available commands.
+After sending `/start` to your bot, the command menu will appear automatically with buttons for the available commands.
 
 ### 👉 Explore MASSA blockchain
 First of all it can observe MASSA explorer and display wallets info with command:

--- a/massa_acheta_docker/main.py
+++ b/massa_acheta_docker/main.py
@@ -65,8 +65,10 @@ async def main() -> None:
 
     t = as_list(
         "🔆 Service successfully started to watch the following nodes:",
-        *nodes_list, "",
-        "👉 Try /help to learn bot commands", "",
+        *nodes_list,
+        "",
+        "👉 Use the command menu to learn bot commands",
+        "",
         f"⏳ Main loop period: {app_config['service']['main_loop_period_min']} minutes",
         f"⚡ Probe timeout: {app_config['service']['http_probe_timeout_sec']} seconds"
     )

--- a/massa_acheta_docker/telegram/handlers/add_node.py
+++ b/massa_acheta_docker/telegram/handlers/add_node.py
@@ -59,8 +59,9 @@ async def input_nodename_to_add(message: Message, state: FSMContext) -> None:
 
     if node_name in app_globals.app_results:
         t = as_list(
-            f"‼ Error: Node with nickname \"{node_name}\" already exists", "",
-            "👉 Try /add_node to add another node or /help to learn bot commands"
+            f"‼ Error: Node with nickname \"{node_name}\" already exists",
+            "",
+            "👉 Try /add_node to add another node or use the command menu for help"
         )
         try:
             await message.reply(

--- a/massa_acheta_docker/telegram/handlers/add_wallet.py
+++ b/massa_acheta_docker/telegram/handlers/add_wallet.py
@@ -34,8 +34,9 @@ async def cmd_add_wallet(message: Message, state: FSMContext) -> None:
     
     if len(app_globals.app_results) == 0:
         t = as_list(
-            "⭕ Node list is empty", "",
-            "👉 Try /add_node to add a node or /help to learn bot commands"
+            "⭕ Node list is empty",
+            "",
+            "👉 Try /add_node to add a node or use the command menu for help"
         )
         try:
             await message.reply(
@@ -79,8 +80,9 @@ async def input_wallet_to_add(message: Message, state: FSMContext) -> None:
     node_name = message.text
     if node_name not in app_globals.app_results:
         t = as_list(
-            f"‼ Error: Unknown node \"{node_name}\"", "",
-            "👉 Try /add_wallet to add another wallet or /help to learn bot commands"
+            f"‼ Error: Unknown node \"{node_name}\"",
+            "",
+            "👉 Try /add_wallet to add another wallet or use the command menu for help"
         )
         try:
             await message.reply(
@@ -145,7 +147,7 @@ async def add_wallet(message: Message, state: FSMContext) -> None:
                 ),
                 f" already attached to node \"{node_name}\""
             ),
-            "👉 Try /add_wallet to add another wallet or /help to learn bot commands"
+            "👉 Try /add_wallet to add another wallet or use the command menu for help"
         )
         try:
             await message.reply(

--- a/massa_acheta_docker/telegram/handlers/chart_wallet.py
+++ b/massa_acheta_docker/telegram/handlers/chart_wallet.py
@@ -34,8 +34,9 @@ async def cmd_chart_wallet(message: Message, state: FSMContext) -> None:
     
     if len(app_globals.app_results) == 0:
         t = as_list(
-            "⭕ Node list is empty", "",
-            "👉 Try /help to learn how to add a node to bot"
+            "⭕ Node list is empty",
+            "",
+            "👉 Use the command menu to learn how to add a node to bot"
         )
         try:
             await message.reply(
@@ -79,8 +80,9 @@ async def select_wallet_to_show(message: Message, state: FSMContext) -> None:
     node_name = message.text
     if node_name not in app_globals.app_results:
         t = as_list(
-            f"‼ Error: Unknown node \"{node_name}\"", "",
-            "👉 Try /view_wallet to view another wallet or /help to learn bot commands"
+            f"‼ Error: Unknown node \"{node_name}\"",
+            "",
+            "👉 Try /view_wallet to view another wallet or use the command menu for help"
         )
         try:
             await message.reply(
@@ -97,8 +99,9 @@ async def select_wallet_to_show(message: Message, state: FSMContext) -> None:
 
     if len(app_globals.app_results[node_name]['wallets']) == 0:
         t = as_list(
-            f"⭕ No wallets attached to node {node_name}", "",
-            "👉 Try /add_wallet to add wallet to the node or /help to learn bot commands"
+            f"⭕ No wallets attached to node {node_name}",
+            "",
+            "👉 Try /add_wallet to add wallet to the node or use the command menu for help"
         )
         try:
             await message.reply(
@@ -159,7 +162,7 @@ async def show_wallet(message: Message, state: FSMContext) -> None:
                 ),
                 f" is not attached to node \"{node_name}\""
             ),
-            "👉 Try /view_wallet to view another wallet or /help to learn bot commands"
+            "👉 Try /view_wallet to view another wallet or use the command menu for help"
         )
         try:
             await message.reply(
@@ -476,7 +479,7 @@ async def show_wallet(message: Message, state: FSMContext) -> None:
         logger.error(f"Cannot prepare wallet chart ({str(E)})")
         t = as_list(
             as_line("🤷 Charts are temporary unavailable. Try later."),
-            as_line("☝ Use /help to learn bot commands")
+            as_line("☝ Use the command menu to learn bot commands")
         )
         try:
             await message.reply(

--- a/massa_acheta_docker/telegram/handlers/delete_node.py
+++ b/massa_acheta_docker/telegram/handlers/delete_node.py
@@ -31,8 +31,9 @@ async def cmd_delete_node(message: Message, state: FSMContext) -> None:
     
     if len(app_globals.app_results) == 0:
         t = as_list(
-            "⭕ Node list is empty", "",
-            "👉 Try /help to learn how to add a node to bot"
+            "⭕ Node list is empty",
+            "",
+            "👉 Use the command menu to learn how to add a node to bot"
         )
         try:
             await message.reply(
@@ -77,8 +78,9 @@ async def delete_node(message: Message, state: FSMContext) -> None:
 
     if node_name not in app_globals.app_results:
         t = as_list(
-            f"‼ Error: Unknown node \"{node_name}\"", "",
-            as_line("👉 Try /delete_node to delete another node or /help to learn bot commands")
+            f"‼ Error: Unknown node \"{node_name}\"",
+            "",
+            as_line("👉 Try /delete_node to delete another node or use the command menu for help")
         )
         try:
             await message.reply(

--- a/massa_acheta_docker/telegram/handlers/delete_wallet.py
+++ b/massa_acheta_docker/telegram/handlers/delete_wallet.py
@@ -32,8 +32,9 @@ async def cmd_delete_wallet(message: Message, state: FSMContext) -> None:
     
     if len(app_globals.app_results) == 0:
         t = as_list(
-            "⭕ Node list is empty", "",
-            "👉 Try /help to learn how to add a node to bot"
+            "⭕ Node list is empty",
+            "",
+            "👉 Use the command menu to learn how to add a node to bot"
         )
         try:
             await message.reply(
@@ -77,8 +78,9 @@ async def select_wallet_to_delete(message: Message, state: FSMContext) -> None:
     node_name = message.text
     if node_name not in app_globals.app_results:
         t = as_list(
-            f"‼ Error: Unknown node \"{node_name}\"", "",
-            "👉 Try /delete_wallet to delete another wallet or /help to learn bot commands"
+            f"‼ Error: Unknown node \"{node_name}\"",
+            "",
+            "👉 Try /delete_wallet to delete another wallet or use the command menu for help"
         )
         try:
             await message.reply(
@@ -95,8 +97,9 @@ async def select_wallet_to_delete(message: Message, state: FSMContext) -> None:
 
     if len(app_globals.app_results[node_name]['wallets']) == 0:
         t = as_list(
-            f"⭕ No wallets attached to node \"{node_name}\"", "",
-            "👉 Try /add_wallet to add a wallet or /help to learn bot commands"
+            f"⭕ No wallets attached to node \"{node_name}\"",
+            "",
+            "👉 Try /add_wallet to add a wallet or use the command menu for help"
         )
         try:
             await message.reply(
@@ -157,7 +160,7 @@ async def delete_wallet(message: Message, state: FSMContext) -> None:
                 ),
                 f" is not attached to node {node_name}"
             ),
-            "👉 Try /delete_wallet to delete another wallet or /help to learn bot commands"
+            "👉 Try /delete_wallet to delete another wallet or use the command menu for help"
         )
         try:
             await message.reply(

--- a/massa_acheta_docker/telegram/handlers/massa_chart.py
+++ b/massa_acheta_docker/telegram/handlers/massa_chart.py
@@ -160,7 +160,7 @@ async def cmd_massa_chart(message: Message) -> None:
         logger.error(f"Cannot prepare MASSA Mainnet chart ({str(E)})")
         t = as_list(
             as_line("🤷 Charts are temporary unavailable. Try later."),
-            as_line("☝ Use /help to learn bot commands")
+            as_line("☝ Use the command menu to learn bot commands")
         )
         try:
             await message.reply(

--- a/massa_acheta_docker/telegram/handlers/reset.py
+++ b/massa_acheta_docker/telegram/handlers/reset.py
@@ -60,8 +60,9 @@ async def do_reset(message: Message, state: FSMContext) -> None:
 
     if message.text.upper() != "I REALLY WANT TO RESET ALL SETTINGS":
         t = as_list(
-            "🤚 Reset request rejected", "",
-            "👉 Try /help to learn bot commands"
+            "🤚 Reset request rejected",
+            "",
+            "👉 Use the command menu to learn bot commands"
         )
         try:
             await message.reply(

--- a/massa_acheta_docker/telegram/handlers/start.py
+++ b/massa_acheta_docker/telegram/handlers/start.py
@@ -3,7 +3,7 @@ from loguru import logger
 from aiogram import Router
 from aiogram.filters import Command, StateFilter
 from aiogram.types import Message
-from telegram.menu import build_help_text, build_help_keyboard
+from telegram.menu import build_menu_text, build_menu_keyboard
 from aiogram.enums import ParseMode
 
 from app_config import app_config
@@ -13,15 +13,15 @@ import app_globals
 router = Router()
 
 
-@router.message(StateFilter(None), Command("start", "help"))
+@router.message(StateFilter(None), Command("start"))
 @logger.catch
 async def cmd_start(message: Message) -> None:
     logger.debug("-> Enter Def")
     logger.info(f"-> Got '{message.text}' command from '{message.from_user.id}'@'{message.chat.id}'")
 
     public = message.chat.id != app_globals.bot.ACHETA_CHAT
-    t = build_help_text(public)
-    keyboard = build_help_keyboard(public)
+    t = build_menu_text(public)
+    keyboard = build_menu_keyboard(public)
 
     try:
         await message.reply(

--- a/massa_acheta_docker/telegram/handlers/unknown.py
+++ b/massa_acheta_docker/telegram/handlers/unknown.py
@@ -19,8 +19,9 @@ async def cmd_unknown(message: Message, state: FSMContext) -> None:
     logger.info(f"-> Got '{message.text}' command from '{message.from_user.id}'@'{message.chat.id}'")
 
     t = as_list(
-        f"⁉ Error: Unknown command", "",
-        "👉 Try /help to learn bot commands"
+        f"⁉ Error: Unknown command",
+        "",
+        "👉 Use the command menu to explore available commands"
     )
     try:
         await message.reply(

--- a/massa_acheta_docker/telegram/handlers/view_address.py
+++ b/massa_acheta_docker/telegram/handlers/view_address.py
@@ -186,7 +186,7 @@ async def get_address(wallet_address: str="") -> Text:
                     f"🧵 Thread: {wallet_thread}", "",
                     *cycles_list, "",
                     *credit_list, "",
-                    "☝ To view ALL deferred credits try /view_credits or /help to learn bot commands"
+                    "☝ To view ALL deferred credits try /view_credits or use the command menu for help"
                 )
         )
 

--- a/massa_acheta_docker/telegram/handlers/view_config.py
+++ b/massa_acheta_docker/telegram/handlers/view_config.py
@@ -57,10 +57,12 @@ async def cmd_view_config(message: Message) -> None:
                 )
 
     t = as_list(
-        "📋 Current service configuration:", "",
+        "📋 Current service configuration:",
+        "",
         *config_list,
-        f"🏃 Bot started: {await get_last_seen(last_time=app_globals.acheta_start_time, show_days=True)}", "",
-        "👉 Try /help to learn how to manage settings"
+        f"🏃 Bot started: {await get_last_seen(last_time=app_globals.acheta_start_time, show_days=True)}",
+        "",
+        "👉 Use the command menu to learn how to manage settings"
     )
     try:
         await message.reply(

--- a/massa_acheta_docker/telegram/handlers/view_node.py
+++ b/massa_acheta_docker/telegram/handlers/view_node.py
@@ -30,8 +30,9 @@ async def cmd_view_node(message: Message, state: FSMContext) -> None:
     
     if len(app_globals.app_results) == 0:
         t = as_list(
-            "⭕ Node list is empty", "",
-            "👉 Try /help to learn how to add a node to bot"
+            "⭕ Node list is empty",
+            "",
+            "👉 Use the command menu to learn how to add a node to bot"
         )
         try:
             await message.reply(
@@ -75,8 +76,9 @@ async def show_node(message: Message, state: FSMContext) -> None:
 
     if node_name not in app_globals.app_results:
         t = as_list(
-            f"‼ Error: Unknown node \"{node_name}\"", "",
-            "👉 Try /view_node to view another node or /help to learn how to add a node to bot"
+            f"‼ Error: Unknown node \"{node_name}\"",
+            "",
+            "👉 Try /view_node to view another node or use the command menu for help"
         )
         try:
             await message.reply(

--- a/massa_acheta_docker/telegram/handlers/view_wallet.py
+++ b/massa_acheta_docker/telegram/handlers/view_wallet.py
@@ -33,8 +33,9 @@ async def cmd_view_wallet(message: Message, state: FSMContext) -> None:
     
     if len(app_globals.app_results) == 0:
         t = as_list(
-            "⭕ Node list is empty", "",
-            "👉 Try /help to learn how to add a node to bot"
+            "⭕ Node list is empty",
+            "",
+            "👉 Use the command menu to learn how to add a node to bot"
         )
         try:
             await message.reply(
@@ -78,8 +79,9 @@ async def select_wallet_to_show(message: Message, state: FSMContext) -> None:
     node_name = message.text
     if node_name not in app_globals.app_results:
         t = as_list(
-            f"‼ Error: Unknown node \"{node_name}\"", "",
-            "👉 Try /view_wallet to view another wallet or /help to learn bot commands"
+            f"‼ Error: Unknown node \"{node_name}\"",
+            "",
+            "👉 Try /view_wallet to view another wallet or use the command menu for help"
         )
         try:
             await message.reply(
@@ -96,8 +98,9 @@ async def select_wallet_to_show(message: Message, state: FSMContext) -> None:
 
     if len(app_globals.app_results[node_name]['wallets']) == 0:
         t = as_list(
-            f"⭕ No wallets attached to node {node_name}", "",
-            "👉 Try /add_wallet to add wallet to the node or /help to learn bot commands"
+            f"⭕ No wallets attached to node {node_name}",
+            "",
+            "👉 Try /add_wallet to add wallet to the node or use the command menu for help"
         )
         try:
             await message.reply(
@@ -158,7 +161,7 @@ async def show_wallet(message: Message, state: FSMContext) -> None:
                 ),
                 f" is not attached to node \"{node_name}\""
             ),
-            "👉 Try /view_wallet to view another wallet or /help to learn bot commands"
+            "👉 Try /view_wallet to view another wallet or use the command menu for help"
         )
         try:
             await message.reply(

--- a/massa_acheta_docker/telegram/menu.py
+++ b/massa_acheta_docker/telegram/menu.py
@@ -43,10 +43,10 @@ def get_bot_commands(public: bool) -> list[BotCommand]:
     commands = PUBLIC_COMMANDS if public else PRIVATE_COMMANDS
     return [BotCommand(command=cmd, description=desc) for cmd, desc in commands]
 
-def build_help_text(public: bool) -> str:
-    """Build help message text in HTML format."""
+def build_menu_text(public: bool) -> str:
+    """Build command menu text in HTML format."""
     commands = PUBLIC_COMMANDS if public else PRIVATE_COMMANDS
-    lines: list[str | object] = ["📖 Commands:", "⦙", "⦙… /start or /help : Show help info", "⦙"]
+    lines: list[str | object] = ["📖 Commands:", "⦙", "⦙… /start : Show command menu", "⦙"]
     for cmd, desc in commands:
         if cmd == "/help":
             continue
@@ -59,7 +59,7 @@ def build_help_text(public: bool) -> str:
     return as_list(*lines).as_html()
 
 
-def build_help_keyboard(public: bool) -> ReplyKeyboardMarkup:
+def build_menu_keyboard(public: bool) -> ReplyKeyboardMarkup:
     """Build a reply keyboard with available commands."""
     commands = PUBLIC_COMMANDS if public else PRIVATE_COMMANDS
     kb = ReplyKeyboardBuilder()

--- a/massa_acheta_docker/tools.py
+++ b/massa_acheta_docker/tools.py
@@ -267,7 +267,7 @@ async def check_privacy(message: Message) -> bool:
                     url="https://github.com/dex2code/massa_acheta"
                 )
             ),
-            "☝ Try /help to get a list of public commands"
+            "☝ Use the command menu to see available public commands"
         )
         await message.answer(
             text=t.as_html(),


### PR DESCRIPTION
## Summary
- replace `/help` references with menu instructions
- handle only `/start` for command menu
- rename `build_help_*` to `build_menu_*`
- update startup text
- document auto menu in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852488c65f083288fc9d2ef89dfead9