### PR TITLE
Ensure persistent menu in handlers

### DIFF
--- a/massa_acheta_docker/telegram/handlers/add_wallet.py
+++ b/massa_acheta_docker/telegram/handlers/add_wallet.py
@@ -2,7 +2,8 @@ from loguru import logger
 
 import asyncio
 from aiogram import Router, F
-from aiogram.types import Message, ReplyKeyboardRemove
+from aiogram.types import Message
+from telegram.menu import build_menu_keyboard
 from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -88,7 +89,7 @@ async def input_wallet_to_add(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -110,7 +111,7 @@ async def input_wallet_to_add(message: Message, state: FSMContext) -> None:
         await message.reply(
             text=t.as_html(),
             parse_mode=ParseMode.HTML,
-            reply_markup=ReplyKeyboardRemove(),
+            reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
             request_timeout=app_config['telegram']['sending_timeout_sec']
         )
     except BaseException as E:

--- a/massa_acheta_docker/telegram/handlers/cancel.py
+++ b/massa_acheta_docker/telegram/handlers/cancel.py
@@ -2,12 +2,14 @@ from loguru import logger
 
 from aiogram import Router
 from aiogram.filters import Command
-from aiogram.types import Message, ReplyKeyboardRemove
+from aiogram.types import Message
+from telegram.menu import build_menu_keyboard
 from aiogram.enums import ParseMode
 from aiogram.fsm.context import FSMContext
 from aiogram.utils.formatting import as_list
 
 from app_config import app_config
+import app_globals
 
 
 router = Router()
@@ -24,10 +26,11 @@ async def cmd_cancel(message: Message, state: FSMContext) -> None:
     )
     try:
         await state.clear()
+        public = message.chat.id != app_globals.bot.ACHETA_CHAT
         await message.reply(
             text=t.as_html(),
             parse_mode=ParseMode.HTML,
-            reply_markup=ReplyKeyboardRemove(),
+            reply_markup=build_menu_keyboard(public),
             request_timeout=app_config['telegram']['sending_timeout_sec']
         )
     except BaseException as E:

--- a/massa_acheta_docker/telegram/handlers/chart_wallet.py
+++ b/massa_acheta_docker/telegram/handlers/chart_wallet.py
@@ -2,7 +2,8 @@ from loguru import logger
 
 from datetime import datetime
 from aiogram import Router, F
-from aiogram.types import Message, ReplyKeyboardRemove
+from aiogram.types import Message
+from telegram.menu import build_menu_keyboard
 from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -88,7 +89,7 @@ async def select_wallet_to_show(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -107,7 +108,7 @@ async def select_wallet_to_show(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -485,7 +486,7 @@ async def show_wallet(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -497,7 +498,7 @@ async def show_wallet(message: Message, state: FSMContext) -> None:
                 photo=staking_chart_url,
                 caption=caption_staking.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
 
@@ -505,7 +506,7 @@ async def show_wallet(message: Message, state: FSMContext) -> None:
                 photo=blocks_chart_url,
                 caption=caption_blocks.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:

--- a/massa_acheta_docker/telegram/handlers/delete_node.py
+++ b/massa_acheta_docker/telegram/handlers/delete_node.py
@@ -1,7 +1,8 @@
 from loguru import logger
 
 from aiogram import Router, F
-from aiogram.types import Message, ReplyKeyboardRemove
+from aiogram.types import Message
+from telegram.menu import build_menu_keyboard
 from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -86,7 +87,7 @@ async def delete_node(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -134,7 +135,7 @@ async def delete_node(message: Message, state: FSMContext) -> None:
         await message.reply(
             text=t.as_html(),
             parse_mode=ParseMode.HTML,
-            reply_markup=ReplyKeyboardRemove(),
+            reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
             request_timeout=app_config['telegram']['sending_timeout_sec']
         )
     except BaseException as E:

--- a/massa_acheta_docker/telegram/handlers/delete_wallet.py
+++ b/massa_acheta_docker/telegram/handlers/delete_wallet.py
@@ -1,7 +1,8 @@
 from loguru import logger
 
 from aiogram import Router, F
-from aiogram.types import Message, ReplyKeyboardRemove
+from aiogram.types import Message
+from telegram.menu import build_menu_keyboard
 from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -86,7 +87,7 @@ async def select_wallet_to_delete(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -105,7 +106,7 @@ async def select_wallet_to_delete(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -166,7 +167,7 @@ async def delete_wallet(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -226,7 +227,7 @@ async def delete_wallet(message: Message, state: FSMContext) -> None:
         await message.reply(
             text=t.as_html(),
             parse_mode=ParseMode.HTML,
-            reply_markup=ReplyKeyboardRemove(),
+            reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
             request_timeout=app_config['telegram']['sending_timeout_sec']
         )
     except BaseException as E:

--- a/massa_acheta_docker/telegram/handlers/unknown.py
+++ b/massa_acheta_docker/telegram/handlers/unknown.py
@@ -1,12 +1,14 @@
 from loguru import logger
 
 from aiogram import Router, F
-from aiogram.types import Message, ReplyKeyboardRemove
+from aiogram.types import Message
+from telegram.menu import build_menu_keyboard
 from aiogram.fsm.context import FSMContext
 from aiogram.utils.formatting import as_list
 from aiogram.enums import ParseMode
 
 from app_config import app_config
+import app_globals
 
 
 router = Router()
@@ -24,9 +26,10 @@ async def cmd_unknown(message: Message, state: FSMContext) -> None:
         "👉 Use the command menu to explore available commands"
     )
     try:
+        public = message.chat.id != app_globals.bot.ACHETA_CHAT
         await message.reply(
             text=t.as_html(),
-            reply_markup=ReplyKeyboardRemove(),
+            reply_markup=build_menu_keyboard(public),
             parse_mode=ParseMode.HTML,
             request_timeout=app_config['telegram']['sending_timeout_sec']
         )

--- a/massa_acheta_docker/telegram/handlers/view_node.py
+++ b/massa_acheta_docker/telegram/handlers/view_node.py
@@ -1,7 +1,8 @@
 from loguru import logger
 
 from aiogram import Router, F
-from aiogram.types import Message, ReplyKeyboardRemove
+from aiogram.types import Message
+from telegram.menu import build_menu_keyboard
 from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -84,7 +85,7 @@ async def show_node(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -159,7 +160,7 @@ async def show_node(message: Message, state: FSMContext) -> None:
         await message.reply(
             text=t.as_html(),
             parse_mode=ParseMode.HTML,
-            reply_markup=ReplyKeyboardRemove(),
+            reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
             request_timeout=app_config['telegram']['sending_timeout_sec']
         )
     except BaseException as E:

--- a/massa_acheta_docker/telegram/handlers/view_wallet.py
+++ b/massa_acheta_docker/telegram/handlers/view_wallet.py
@@ -2,7 +2,8 @@ from loguru import logger
 
 from datetime import datetime
 from aiogram import Router, F
-from aiogram.types import Message, ReplyKeyboardRemove
+from aiogram.types import Message
+from telegram.menu import build_menu_keyboard
 from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -87,7 +88,7 @@ async def select_wallet_to_show(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -106,7 +107,7 @@ async def select_wallet_to_show(message: Message, state: FSMContext) -> None:
             await message.reply(
                 text=t.as_html(),
                 parse_mode=ParseMode.HTML,
-                reply_markup=ReplyKeyboardRemove(),
+                reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
                 request_timeout=app_config['telegram']['sending_timeout_sec']
             )
         except BaseException as E:
@@ -307,7 +308,7 @@ async def show_wallet(message: Message, state: FSMContext) -> None:
         await message.reply(
             text=t.as_html(),
             parse_mode=ParseMode.HTML,
-            reply_markup=ReplyKeyboardRemove(),
+            reply_markup=build_menu_keyboard(message.chat.id != app_globals.bot.ACHETA_CHAT),
             request_timeout=app_config['telegram']['sending_timeout_sec']
         )
     except BaseException as E:

--- a/massa_acheta_docker/telegram/menu.py
+++ b/massa_acheta_docker/telegram/menu.py
@@ -66,4 +66,4 @@ def build_menu_keyboard(public: bool) -> ReplyKeyboardMarkup:
     for cmd, _ in commands:
         kb.button(text=cmd)
     kb.adjust(2)
-    return kb.as_markup(resize_keyboard=True)
+    return kb.as_markup(resize_keyboard=True, is_persistent=True)


### PR DESCRIPTION
## Summary
- make menu keyboard persistent
- show the command menu again after handlers respond

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_6852e6bd850083289e7dc8d3ea8a7268